### PR TITLE
useQuery hook types should not assume that data is populated by default

### DIFF
--- a/packages/redux-requests-react/types/index.d.ts
+++ b/packages/redux-requests-react/types/index.d.ts
@@ -91,7 +91,7 @@ export function useQuery<
   suspense?: boolean;
   suspenseSsr?: boolean;
 }): QueryState<
-  Data extends undefined ? GetQueryStateData<QueryCreator> : Data
+  Data extends undefined ? GetQueryStateData<QueryCreator> | undefined : Data
 > & {
   load: () => Promise<{
     data?: QueryState<

--- a/packages/redux-requests-react/types/index.d.ts
+++ b/packages/redux-requests-react/types/index.d.ts
@@ -91,7 +91,7 @@ export function useQuery<
   suspense?: boolean;
   suspenseSsr?: boolean;
 }): QueryState<
-  Data extends undefined ? GetQueryStateData<QueryCreator> | undefined : Data
+  Data extends undefined ? GetQueryStateData<QueryCreator> | null : Data
 > & {
   load: () => Promise<{
     data?: QueryState<


### PR DESCRIPTION
The useQuery hook types aren't strict enough. This should probably be a minor version bump since some projects may see new type errors in the places where they have dangerous use of the ____.data attribute.

If I have an action like: 

```
type ListResponse = {
   results: Array<number>;
};

export const fetchList = createAction(
  'list/fetch',
  (): RequestAction<ListResponse> => ({
    request: { url: '/api/list' },
  }),
);
```

And then a react component like
```
const ListView: React.FunctionComponent = () => {
   
  const { data, loading } = useQuery({ type: fetchList });
  
  // type of data is inferred to be *ListResponse*. Data here could still be unpopulated
};
```

The current typings already acknowledge that this scenario exists:

```
export function useQuery<
  Data = undefined,
  QueryCreator extends RequestCreator = any
>(...): QueryState<
  Data extends undefined ? GetQueryStateData<QueryCreator> : Data
> & {
  load: () => Promise<{
    data?: QueryState<
      Data extends undefined ? GetQueryStateData<QueryCreator> : Data
    >;
    error?: any;
    ...
  }>;
  ...
};
```
Note that "load" promise returning an optional error or optional data. useQuery at runtime returns ~undefined~ null data if the request is still loading or if there is an error.