### PR TITLE
chore: enable ts strict mode

### DIFF
--- a/packages/redux-requests-axios/package.json
+++ b/packages/redux-requests-axios/package.json
@@ -25,7 +25,7 @@
     "lint": "eslint 'src/**'",
     "test": "jest src",
     "test:cover": "jest --coverage src",
-    "test-types": "tsc types/index.d.spec.ts --noEmit --lib es2015",
+    "test-types": "tsc types/index.d.spec.ts --noEmit --strict --lib es2015",
     "build:commonjs": "cross-env BABEL_ENV=cjs babel src --out-dir lib --ignore 'src/**/*.spec.js'",
     "build:es": "cross-env babel src --out-dir es --ignore 'src/**/*.spec.js'",
     "build:umd": "webpack --mode development -o dist --output-filename redux-requests-axios.js",

--- a/packages/redux-requests-fetch/package.json
+++ b/packages/redux-requests-fetch/package.json
@@ -25,7 +25,7 @@
     "lint": "eslint 'src/**'",
     "test": "jest src",
     "test:cover": "jest --coverage src",
-    "test-types": "tsc types/index.d.spec.ts --noEmit --lib es2015",
+    "test-types": "tsc types/index.d.spec.ts --noEmit --strict --lib es2015",
     "build:commonjs": "cross-env BABEL_ENV=cjs babel src --out-dir lib --ignore 'src/**/*.spec.js'",
     "build:es": "babel src --out-dir es --ignore 'src/**/*.spec.js'",
     "build:umd": "webpack --mode development -o dist --output-filename redux-requests-fetch.js",

--- a/packages/redux-requests-graphql/package.json
+++ b/packages/redux-requests-graphql/package.json
@@ -24,7 +24,7 @@
     "lint": "eslint 'src/**'",
     "test": "jest src",
     "test:cover": "jest --coverage src",
-    "test-types": "tsc types/index.d.spec.ts --noEmit --lib es2015",
+    "test-types": "tsc types/index.d.spec.ts --noEmit --strict --lib es2015",
     "build:commonjs": "cross-env BABEL_ENV=cjs babel src --out-dir lib --ignore 'src/**/*.spec.js'",
     "build:es": "babel src --out-dir es --ignore 'src/**/*.spec.js'",
     "build:umd": "webpack --mode development -o dist --output-filename redux-requests-graphql.js",

--- a/packages/redux-requests-mock/package.json
+++ b/packages/redux-requests-mock/package.json
@@ -26,7 +26,7 @@
     "lint": "eslint 'src/**'",
     "test": "jest src",
     "test:cover": "jest --coverage src",
-    "test-types": "tsc types/index.d.spec.ts --noEmit --lib es2015",
+    "test-types": "tsc types/index.d.spec.ts --noEmit --strict --lib es2015",
     "build:commonjs": "cross-env BABEL_ENV=cjs babel src --out-dir lib --ignore 'src/**/*.spec.js'",
     "build:es": "babel src --out-dir es --ignore 'src/**/*.spec.js'",
     "build:umd": "webpack --mode development -o dist --output-filename redux-requests-mock.js",

--- a/packages/redux-requests-promise/package.json
+++ b/packages/redux-requests-promise/package.json
@@ -25,7 +25,7 @@
     "lint": "eslint 'src/**'",
     "test": "jest src",
     "test:cover": "jest --coverage src",
-    "test-types": "tsc types/index.d.spec.ts --noEmit --lib es2015,DOM",
+    "test-types": "tsc types/index.d.spec.ts --noEmit --strict --lib es2015,DOM",
     "build:commonjs": "cross-env BABEL_ENV=cjs babel src --out-dir lib --ignore 'src/**/*.spec.js'",
     "build:es": "babel src --out-dir es --ignore 'src/**/*.spec.js'",
     "build:umd": "webpack --mode development -o dist --output-filename redux-requests-promise.js",

--- a/packages/redux-requests-react/package.json
+++ b/packages/redux-requests-react/package.json
@@ -24,7 +24,7 @@
     "lint": "eslint 'src/**'",
     "test": "jest src",
     "test:cover": "jest --coverage src",
-    "test-types": "tsc types/index.d.spec.tsx --noEmit --lib es2015 --jsx react",
+    "test-types": "tsc types/index.d.spec.tsx --noEmit --strict --lib es2015 --jsx react",
     "build:commonjs": "cross-env BABEL_ENV=cjs babel src --out-dir lib --ignore 'src/**/*.spec.js'",
     "build:es": "babel src --out-dir es --ignore 'src/**/*.spec.js'",
     "build:umd": "webpack --mode development -o dist --output-filename redux-requests-react.js",

--- a/packages/redux-requests-react/types/index.d.spec.tsx
+++ b/packages/redux-requests-react/types/index.d.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { RequestAction } from '@redux-requests/core';
+import { MutationState, QueryState, RequestAction } from '@redux-requests/core';
 
 import {
   Query,
@@ -115,28 +115,19 @@ function Error({ error, extra }) {
   );
 }
 
-function Component({ query, extra }) {
+function Component({ query, extra }: { query: QueryState<number>, extra: any }) {
   return (
     <div>
-      {query.data as number} {extra}
+      {query.data} {extra}
     </div>
   );
 }
 
 function QueryWithComponents() {
   return (
-    <Query<string>
+    <Query
       type="QUERY"
       component={Component}
-      loadingComponent={Spinner}
-      loadingComponentProps={{
-        extra: 'extra',
-      }}
-      errorComponent={Error}
-      errorComponentProps={{ extra: 'extra' }}
-      noDataMessage={<span>No data</span>}
-      showLoaderDuringRefetch={false}
-      isDataEmpty={query => true}
     />
   );
 }
@@ -154,7 +145,7 @@ function BasicMutation() {
   );
 }
 
-function MutationComponent({ mutation, extra }) {
+function MutationComponent({ mutation, extra }: { mutation: MutationState, extra: any }) {
   return (
     <div>
       {mutation.loading && 'loading'}

--- a/packages/redux-requests-react/types/index.d.spec.tsx
+++ b/packages/redux-requests-react/types/index.d.spec.tsx
@@ -103,11 +103,11 @@ function BasicQuery2() {
   return <Query type={fetchBooks}>{({ data }) => data}</Query>;
 }
 
-function Spinner({ extra }) {
+function Spinner({ extra }: { extra: any }) {
   return <span>loading... {extra}</span>;
 }
 
-function Error({ error, extra }) {
+function Error({ error, extra }: { error: Error, extra: any }) {
   return (
     <span>
       {error} {extra}
@@ -194,9 +194,9 @@ const QueryDispatcher = () => {
     <button
       onClick={async () => {
         const response = await dispatch(fetchBooks(1, '1', { a: false }));
-        response.data.parsed;
+        response.data?.parsed;
         const response2 = await dispatch(fetchBook('1'));
-        response2.data.title;
+        response2.data?.title;
       }}
     >
       Make a query

--- a/packages/redux-requests-react/types/index.d.ts
+++ b/packages/redux-requests-react/types/index.d.ts
@@ -140,9 +140,11 @@ export function useSubscription<SC extends SubscriptionCreator = any>(props: {
 
 export function useDispatchRequest(): DispatchRequest;
 
-interface RequestsProviderProps {
+type RequestsProviderProps =
+  ({ requestsConfig: HandleRequestConfig; store?: never; }
+  | { store: Store; requestsConfig?: never; })
+& {
   children: React.ReactNode;
-  requestsConfig: HandleRequestConfig;
   extraReducers?: Reducer[];
   getMiddleware?: (extraMiddleware: Middleware[]) => Middleware[];
   autoLoad?: boolean;
@@ -150,10 +152,9 @@ interface RequestsProviderProps {
   throwError?: boolean;
   suspense?: boolean;
   suspenseSsr?: boolean;
-  store?: Store;
   getStore?: (store: RequestsStore) => void;
   initialState?: any;
-}
+};
 
 export class RequestsProvider extends React.Component<RequestsProviderProps> {}
 

--- a/packages/redux-requests-react/types/index.d.ts
+++ b/packages/redux-requests-react/types/index.d.ts
@@ -21,7 +21,12 @@ interface ErrorProps {
   [errorProp: string]: any;
 }
 
-interface QueryProps<QueryStateData> {
+interface QueryCustomComponentProps<QueryStateData> {
+  query: QueryState<QueryStateData>;
+  [extraProperty: string]: any;
+}
+
+interface QueryProps<QueryStateData, CustomComponentProps> {
   type?: string | ((...params: any[]) => RequestAction<any, QueryStateData>);
   action?: (...params: any[]) => RequestAction<any, QueryStateData>;
   requestKey?: string;
@@ -29,10 +34,7 @@ interface QueryProps<QueryStateData> {
   defaultData?: any;
   selector?: (state: any) => QueryState<QueryStateData>;
   children?: (query: QueryState<QueryStateData>) => React.ReactNode;
-  component?: React.ComponentType<{
-    query: QueryState<QueryStateData>;
-    [extraProperty: string]: any;
-  }>;
+  component?: CustomComponentProps extends QueryCustomComponentProps<QueryStateData> ? React.ComponentType<CustomComponentProps> : never;
   isDataEmpty?: (query: QueryState<QueryStateData>) => boolean;
   showLoaderDuringRefetch?: boolean;
   noDataMessage?: React.ReactNode;
@@ -43,23 +45,25 @@ interface QueryProps<QueryStateData> {
   [extraProperty: string]: any;
 }
 
-export class Query<QueryStateData = any> extends React.Component<
-  QueryProps<QueryStateData>
+export class Query<QueryStateData = any, CustomComponentProps = {}> extends React.Component<
+  QueryProps<QueryStateData, CustomComponentProps>
 > {}
 
-interface MutationProps {
+interface MutationCustomComponentProps {
+  mutation: MutationState;
+  [extraProperty: string]: any;
+}
+
+interface MutationProps<CustomComponentProps> {
   type?: string | ((...params: any[]) => RequestAction);
   requestKey?: string;
   selector?: (state: any) => MutationState;
   children?: (mutation: MutationState) => React.ReactNode;
-  component?: React.ComponentType<{
-    mutation: MutationState;
-    [extraProperty: string]: any;
-  }>;
+  component?: CustomComponentProps extends MutationCustomComponentProps ? React.ComponentType<CustomComponentProps> : never;
   [extraProperty: string]: any;
 }
 
-export class Mutation extends React.Component<MutationProps> {}
+export class Mutation<CustomComponentProps = {}> extends React.Component<MutationProps<CustomComponentProps>> {}
 
 interface RequestCreator<QueryStateData = any> {
   (...args: any[]): RequestAction<any, QueryStateData>;

--- a/packages/redux-requests-react/types/index.d.ts
+++ b/packages/redux-requests-react/types/index.d.ts
@@ -141,12 +141,13 @@ export function useSubscription<SC extends SubscriptionCreator = any>(props: {
 export function useDispatchRequest(): DispatchRequest;
 
 type RequestsProviderProps =
-  ({ requestsConfig: HandleRequestConfig; store?: never; }
-  | { store: Store; requestsConfig?: never; })
+  ({ requestsConfig: HandleRequestConfig;
+    extraReducers?: Reducer[];
+    getMiddleware?: (extraMiddleware: Middleware[]) => Middleware[];
+    store?: never; }
+  | { store: Store; requestsConfig?: never; extraReducers?: never; getMiddleware?: never; })
 & {
   children: React.ReactNode;
-  extraReducers?: Reducer[];
-  getMiddleware?: (extraMiddleware: Middleware[]) => Middleware[];
   autoLoad?: boolean;
   autoReset?: boolean;
   throwError?: boolean;

--- a/packages/redux-requests/package.json
+++ b/packages/redux-requests/package.json
@@ -26,7 +26,7 @@
     "lint": "eslint 'src/**'",
     "test": "jest src",
     "test:cover": "jest --coverage src",
-    "test-types": "tsc types/index.d.spec.ts --noEmit --lib es2015",
+    "test-types": "tsc types/index.d.spec.ts --noEmit --strict --lib es2015",
     "build:commonjs": "cross-env BABEL_ENV=cjs babel src --out-dir lib --ignore 'src/**/*.spec.js'",
     "build:es": "babel src --out-dir es --ignore 'src/**/*.spec.js'",
     "build:umd": "webpack --mode development -o dist --output-filename redux-requests.js",

--- a/packages/redux-requests/types/index.d.spec.ts
+++ b/packages/redux-requests/types/index.d.spec.ts
@@ -59,12 +59,8 @@ const fetchBook: (
   };
 };
 
-let dummyDriver: Driver;
-dummyDriver({}, requestAction, {})
-  .then(v => v)
-  .catch(e => {
-    throw e;
-  });
+const dummyDriver: Driver = ({}, requestAction, {}) =>
+  new Promise<void>((resolve) => { resolve() });
 
 handleRequests({ driver: dummyDriver });
 handleRequests({

--- a/packages/redux-requests/types/index.d.spec.ts
+++ b/packages/redux-requests/types/index.d.spec.ts
@@ -48,6 +48,14 @@ const requestAction: RequestAction = {
   },
 };
 
+const accessRequestActionProps = (requestAction: RequestAction) => {
+  if (requestAction.request !== undefined) {
+    // this request action has an existing `request` key
+  } else if (requestAction.payload !== undefined) {
+    // this request action has an existing `payload` key
+  }
+}
+
 const fetchBook: (
   id: string,
 ) => RequestAction<{ id: string; title: string }> = () => {

--- a/packages/redux-requests/types/index.d.ts
+++ b/packages/redux-requests/types/index.d.ts
@@ -77,6 +77,7 @@ interface RequestActionMeta<Data, TransformedData> {
 export type RequestAction<Data = any, TransformedData = Data> =
   | {
       type?: string;
+      payload?: never;
       request: any | any[];
       meta?: RequestActionMeta<Data, TransformedData>;
     }
@@ -85,6 +86,7 @@ export type RequestAction<Data = any, TransformedData = Data> =
       payload: {
         request: any | any[];
       };
+      request?: never;
       meta?: RequestActionMeta<Data, TransformedData>;
     };
 

--- a/packages/redux-requests/types/index.d.ts
+++ b/packages/redux-requests/types/index.d.ts
@@ -133,7 +133,7 @@ export type SubscriptionAction =
 
 type ResponseData<
   Request extends (...args: any[]) => RequestAction
-> = ReturnType<ReturnType<Request>['meta']['getData']>;
+> = ReturnType<NonNullable<ReturnType<Request>['meta']>['getData']>;
 
 type ActionTypeModifier = (actionType: string) => string;
 


### PR DESCRIPTION
This PR enables typescript `strict` flag on all packages `test-types` npm scripts.
It is recommended for libraries as it would prevent any consumer to use strict mode w/o forking - patches (what we do internally).

All accompanying changes should be non-breaking, barring any error on my part.

`redux-requests`:
  - fix to `dummyDriver` definition (wouldn't pass as previously defined in `strict` mode)
  - make `RequestAction` properties `payload` & `request` (which are already mutually exclusive) testable (add the exclusive keys with a value of `never` in an union where they are non-existent)
  - add a property access test on `RequestAction` (tests that the above change works properly)
  - fix `ResponseData` definition (an union of an object type | `undefined` won't allow accessing the keys of the object anymore in `strict` mode)

`redux-requests-react`:
  - the `Query` & `Mutation` classes type definitions now have an additional generic type named `CustomComponentProps` (which defaults to `{}` for backward compatibility), in turned used respectively in `QueryProps` & `MutationProps` interfaces to be used in an inference check on the `component` prop through new `QueryCustomComponentProps` & `MutationCustomComponentProps` interfaces.
  This allows excess props on custom components, a standard assignation not allowing extra properties to be assigned to an index signature in strict mode.
  I adjusted the tests accordingly.
  - make `RequestsProviderProps` properties `requestsConfig` & `store` mutually exclusive (as stated [in documentation](https://redux-requests.klisiczynski.com/docs/guides/usage-with-react#requestsprovider) and enforced at runtime), i had to convert the interface to a type (to add an intersection)
  - type a few functions arguments in `index.d.spec.tsx`
  - use optional chaining operator for `response.data.prop` tests in `index.d.spec.tsx`, where `data` can be undefined